### PR TITLE
Refactor: 오브젝트 목록에 Image 추가 및 추상화 적용

### DIFF
--- a/DrawingApp/DrawingApp/DrawingSection.swift
+++ b/DrawingApp/DrawingApp/DrawingSection.swift
@@ -3,9 +3,8 @@ import UIKit
 class DrawingSection: UIView {
     
     var delegate: DrawingSectionDelegate?
-    
-    var rectangle: [String: UIView] = [:]
-    var image: [String: UIImageView] = [:]
+
+    var drawingObject: [String: UIView] = [:]
 
     private let drawingView: UIView = {
         let view = UIView()
@@ -67,40 +66,36 @@ class DrawingSection: UIView {
         ])
     }
 
-    func addRectangle(id: String, rectangleView: UIView) {
-        self.rectangle[id] = rectangleView
-        self.drawingView.addSubview(rectangleView)
-    }
-
-    func addImage(id: String, imageView: UIImageView) {
-        self.image[id] = imageView
-        // self.drawingView.addSubview(imageView)
+    func addObject(id: String, objectView: UIView) {
+        self.drawingObject[id] = objectView
+        self.drawingView.addSubview(objectView)
     }
     
-    func setRectangleBorder(selectedRectangle: String, state: BorderState) {
+    func setObjectBorder(selectedObject: String, state: BorderState) {
         switch state {
         case .selected:
-            self.rectangle[selectedRectangle]!.layer.borderWidth = CGFloat(5.0)
-            self.rectangle[selectedRectangle]!.layer.borderColor = CGColor(red: 0.0, green: 0.0, blue: 1.0, alpha: 1.0)
+            self.drawingObject[selectedObject]!.layer.borderWidth = CGFloat(5.0)
+            self.drawingObject[selectedObject]!.layer.borderColor = CGColor(red: 0.0, green: 0.0, blue: 1.0, alpha: 1.0)
         case .unselected:
-            self.rectangle[selectedRectangle]!.layer.borderWidth = CGFloat(0.0)
+            self.drawingObject[selectedObject]!.layer.borderWidth = CGFloat(0.0)
         }
     }
 
+    func getRectangleColor(id: String) -> UIColor? {
+        return self.drawingObject[id]?.backgroundColor
+    }
+
+    func getObjectAlpha(id: String) -> Float {
+        return Float(self.drawingObject[id]?.alpha ?? 1.0)
+    }
+
     func setRectangleColor(id: String, color: UIColor?) {
-        rectangle[id]?.backgroundColor = color?.withAlphaComponent(rectangle[id]?.backgroundColor?.alphaFloat ?? 1.0)
+        guard drawingObject[id] as? UIImageView == nil else { return }
+        drawingObject[id]?.backgroundColor = color?.withAlphaComponent(drawingObject[id]?.backgroundColor?.alphaFloat ?? 1.0)
     }
 
-    func setRectangleAlpha(id: String, alpha: Float) {
-        let color = self.rectangle[id]!.backgroundColor!.rgbFloat
-        let r = color.red
-        let g = color.green
-        let b = color.blue
-        self.rectangle[id]!.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: CGFloat(alpha / 10.0))
-    }
-
-    func getRectangleColor(id: String) -> UIColor {
-        return self.rectangle[id]?.backgroundColor! ?? UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
+    func setObjectAlpha(id: String, alpha: Float) {
+        self.drawingObject[id]!.alpha = CGFloat(alpha)/10
     }
 
     @objc func addRectangleButtonTouched() {

--- a/DrawingApp/DrawingApp/Model/Plane.swift
+++ b/DrawingApp/DrawingApp/Model/Plane.swift
@@ -43,10 +43,6 @@ struct Plane {
         (self.drawingObject[id] as? Rectangle)?.B = B
     }
 
-    func setRectangleAlpha(id: String, alpha: Float) {
-        (self.drawingObject[id] as? Rectangle)?.frame.alpha = Int(alpha)
-    }
-
     mutating func setObjectAlpha(id: String, alpha: Float) {
         self.drawingObject[id]!.frame.alpha = Int(alpha)
     }

--- a/DrawingApp/DrawingApp/StatusSection.swift
+++ b/DrawingApp/DrawingApp/StatusSection.swift
@@ -81,18 +81,24 @@ class StatusSection: UIView {
         ])
     }
 
-    func setUserInteractionEnabled(isEnable: Bool) {
+    func setColorStatusEnabled(isEnable: Bool) {
         self.backgroundColorStatus.isUserInteractionEnabled = isEnable
-        self.alphaStatus.isUserInteractionEnabled = isEnable
 
         if isEnable == false {
             self.backgroundColorStatus.text = "None"
+        }
+
+        self.backgroundColorStatus.layer.opacity = isEnable ? Float(1.0): Float(0.5)
+    }
+
+    func setAlphaStatusEnabled(isEnable: Bool) {
+        self.alphaStatus.isUserInteractionEnabled = isEnable
+
+        if isEnable == false {
             self.alphaStatus.value = 5
         }
 
-        let opacity = isEnable ? Float(1.0): Float(0.5)
-        self.backgroundColorStatus.layer.opacity = opacity
-        self.alphaStatus.layer.opacity = opacity
+        self.alphaStatus.layer.opacity = isEnable ? Float(1.0): Float(0.5)
     }
 
     func setColor(color: UIColor) {


### PR DESCRIPTION
1. ViewController.selectedRectangle -> selectedObject로 변경
2. Rectangle과 Image가 공통으로 쓸 수 있는 함수 추상화
  - DrawingSection
    - rectangle, image -> drawingObject로 통합
      - addRectangle()/addImage() -> addObject로 통합
      - setRectangleBorder -> setObjectBorder()로 변경
      - getObjectAlpha() 추가
  - StatusSection
    - setUserInteractionEnabled() -> setColorStatusEnabled()/setAlphaStautsEnabled()로 분리
  - Plane
    - setRectangleAlpha() -> setObjectAlpha()로 변경
  - ViewController.gestureRecognizer() 내부 로직 수정
3. Rectangle과 Image의 투명도를 공통으로 처리하기 위해 저장 체계 수정
    - backgroundColor의 UIColor.alpha속성 대신, UIView.alpha를 사용하는 것으로 변경
        - UIImageView는 backgroundColor가 nil이기 때문에, 일관적으로 관리하기 위함
        - backgroundColor가 nil이면 UIImageView이므로, gestureRecognizer에서 drawingObject의 종류를 확인하는 데에 활용
